### PR TITLE
Override squarespace padding.

### DIFF
--- a/src/styles.scss
+++ b/src/styles.scss
@@ -264,3 +264,8 @@ table {
   text-align: center;
   font-size: 0.75em;
 }
+
+#site {
+    /* When deployed on squarespace, this prevents spurious padding */
+    padding: 0 !important;
+}


### PR DESCRIPTION
When deployed on squarespace, we need to compensate for the default padding in the template.
